### PR TITLE
Add functional array helpers in forms

### DIFF
--- a/packages/forms/src/useField.ts
+++ b/packages/forms/src/useField.ts
@@ -60,10 +60,18 @@ export default function useField<T = string, C = ChangeEvent<HTMLInputElement>>(
         valid: !errorMessage,
       }))
     } else {
-      setField((field: Field<T>) => ({
-        ...field,
-        ...data,
-      }))
+      setField((field: Field<T>) => {
+        const next = { ...field, ...data }
+        if (data.touched && data.touched !== field.touched) {
+          const errorMessage = _validate(field.value)
+          return {
+            ...next,
+            errorMessage,
+            valid: !errorMessage,
+          }
+        }
+        return next
+      })
     }
   }
 

--- a/packages/forms/src/useField.ts
+++ b/packages/forms/src/useField.ts
@@ -93,7 +93,7 @@ export default function useField<T = string, C = ChangeEvent<HTMLInputElement>>(
   // Only show errrorMessage and validation styles if the field is touched according to the config
   const errorMessage = field.touched ? field.errorMessage : undefined
 
-  const touch = () => update({ touched: false })
+  const touch = () => update({ touched: true })
   const untouch = () => update({ touched: false })
 
   function getListeners() {

--- a/packages/forms/src/useForm.ts
+++ b/packages/forms/src/useForm.ts
@@ -209,13 +209,13 @@ export default function useForm<S extends ZodRawShape>(
       field.reset()
     }
 
-    useEffect(() => {
-      fieldsRef.current[name] = {
-        ref,
-        update: field.update,
-        reset,
-      }
+    fieldsRef.current[name] = {
+      ref,
+      update: field.update,
+      reset,
+    }
 
+    useEffect(() => {
       return () => {
         delete fieldsRef.current[name]
       }

--- a/packages/forms/src/useForm.ts
+++ b/packages/forms/src/useForm.ts
@@ -41,7 +41,7 @@ type PathImpl<T extends ZodTypeAny> = T extends ZodObject<
     }[keyof U & string]
   : T extends ZodArray<infer V>
     ? V extends ZodTypeAny
-      ? `${number}` | `${number}.${PathImpl<V>}`
+      ? `${string}` | `${string}.${PathImpl<V>}`
       : never
     : never
 

--- a/packages/forms/src/useForm.ts
+++ b/packages/forms/src/useForm.ts
@@ -252,10 +252,8 @@ export default function useForm<S extends ZodRawShape>(
         counterRef.current = initialIds.length
         return initialIds
       }
-      const first = `${prefix}-0`
-      arraysRef.current[name as string] = [first]
-      counterRef.current = 1
-      return [first]
+
+      return []
     })
 
     useEffect(() => {
@@ -293,20 +291,7 @@ export default function useForm<S extends ZodRawShape>(
       fieldsRef.current = next
     }
 
-    const fieldsArray = ids.map((id) => ({
-      id,
-      useFormField<P extends ArrayChildKeys<S, K>, T = string, C = ChangeEvent<HTMLInputElement>>(
-        child: P,
-        options?: Omit<Options<T>, 'formatErrorMessage' | 'name' | '_onUpdateValue'>
-      ) {
-        return useFormField<T, C>(
-          `${String(name)}.${id}.${child}` as PathKeys<S>,
-          options
-        )
-      },
-    }))
-
-    return { fields: fieldsArray, append, remove }
+    return { ids, append, remove }
   }
 
   function touchFields() {

--- a/packages/forms/src/useForm.ts
+++ b/packages/forms/src/useForm.ts
@@ -1,5 +1,13 @@
 import { useEffect, useRef, useState, FormEvent, ChangeEvent } from 'react'
-import { z, ZodObject, ZodError, ZodRawShape, ZodIssue } from 'zod'
+import {
+  z,
+  ZodObject,
+  ZodError,
+  ZodRawShape,
+  ZodIssue,
+  ZodTypeAny,
+  ZodArray,
+} from 'zod'
 
 import { Field, Options } from './types.js'
 import defaultFormatErrorMessage from './defaultFormatErrorMessage.js'
@@ -22,14 +30,63 @@ type FieldReference = {
 }
 
 type FieldsMap = Record<string, FieldReference>
+type ArraysMap = Record<string, string[]>
+type ArrayValuesMap = Record<string, Record<string, any>>
 
-function mapFieldsToData(fields: Record<string, any>): Record<string, any> {
-  const obj: Record<string, any> = {}
-  for (const name in fields) {
-    obj[name] = fields[name].ref.current.value
+export type PathKeys<T extends ZodRawShape> =
+  | (keyof T & string)
+  | `${keyof T & string}.${string}`
+
+type ArrayKeys<S extends ZodRawShape> = {
+  [K in keyof S]: S[K] extends ZodArray<any> ? K : never
+}[keyof S]
+
+type ArrayValue<T> = T extends ZodArray<infer U> ? z.infer<U> : never
+
+function setDeepValue(
+  obj: Record<string, any>,
+  path: string[],
+  value: any,
+  arrays: ArraysMap
+): Record<string, any> {
+  if (path.length === 0) {
+    return obj
   }
 
-  return obj
+  const [head, ...rest] = path
+  const arrayIds = arrays[head]
+
+  if (arrayIds) {
+    const [id, ...next] = rest
+    const index = arrayIds.indexOf(id)
+    const target = Array.isArray(obj[head]) ? obj[head] : []
+    const item = setDeepValue(target[index] || {}, next, value, arrays)
+    const nextArray = target.map((v: any, i: number) => (i === index ? item : v))
+    if (index >= target.length) {
+      return {
+        ...obj,
+        [head]: [...nextArray, ...Array(index - target.length).fill({}), item],
+      }
+    }
+    return { ...obj, [head]: nextArray }
+  }
+
+  if (rest.length === 0) {
+    return { ...obj, [head]: value }
+  }
+
+  return {
+    ...obj,
+    [head]: setDeepValue(obj[head] || {}, rest, value, arrays),
+  }
+}
+
+function mapFieldsToData(fields: Record<string, any>, arrays: ArraysMap): Record<string, any> {
+  return Object.keys(fields).reduce(
+    (acc, name) =>
+      setDeepValue(acc, name.split('.'), fields[name].ref.current.value, arrays),
+    {}
+  )
 }
 
 export default function useForm<S extends ZodRawShape>(
@@ -37,23 +94,77 @@ export default function useForm<S extends ZodRawShape>(
   formatErrorMessage: (
     error: ZodIssue,
     value: any,
-    name: string
+    name?: string
   ) => string = defaultFormatErrorMessage
 ) {
   const [fields, setFields] = useState<FieldsMap>({})
+  const arraysRef = useRef<ArraysMap>({})
+  const arrayValuesRef = useRef<ArrayValuesMap>({})
+
+  function getSchema(path: string): ZodTypeAny {
+    const parts = path.split('.')
+    let current: ZodTypeAny = schema
+
+    for (let i = 0; i < parts.length; i++) {
+      const part = parts[i]
+
+      if (current instanceof ZodObject) {
+        current = current.shape[part]
+        continue
+      }
+
+      if (current instanceof ZodArray) {
+        const element: ZodTypeAny = (current as any).element || (current as any)._def.type
+        current = element
+
+        if (arraysRef.current[parts[i - 1]]) {
+          // skip array id segment
+          continue
+        }
+
+        if (/^\d+$/.test(part)) {
+          continue
+        }
+
+        if (current instanceof ZodObject) {
+          current = current.shape[part]
+        }
+      }
+    }
+
+    return current
+  }
+
+  function getDefaultValue(path: string) {
+    const parts = path.split('.')
+    for (let i = 0; i < parts.length; i++) {
+      const arrName = parts[i]
+      const ids = arraysRef.current[arrName]
+      if (!ids) continue
+      const id = parts[i + 1]
+      const rest = parts.slice(i + 2).join('.')
+      const value = arrayValuesRef.current[arrName]?.[id]
+      if (value && rest) {
+        return rest.split('.').reduce((acc, key) => acc?.[key], value)
+      }
+    }
+    return undefined
+  }
 
   function useFormField<T = string, C = ChangeEvent<HTMLInputElement>>(
-    name: keyof S,
+    name: PathKeys<S>,
     options: Omit<
       Options<T>,
       'formatErrorMessage' | 'name' | '_onUpdateValue'
     > = {}
   ) {
-    const shape = schema.shape[name]
+    const shape = getSchema(name)
+    const defaultValue = options.value ?? getDefaultValue(name)
     // @ts-ignore
     const field = useField<T, C>(shape, {
       ...options,
-      name: name as string,
+      name,
+      value: defaultValue,
       formatErrorMessage,
       _onUpdateValue: (value, dirty) => {
         ref.current = {
@@ -96,6 +207,81 @@ export default function useForm<S extends ZodRawShape>(
     }
   }
 
+  function useFieldArray<K extends ArrayKeys<S>>(
+    name: K,
+    initial: ArrayValue<S[K]>[] = []
+  ) {
+    const [ids, setIds] = useState<string[]>(() => {
+      const existing = arraysRef.current[name as string]
+      if (existing && existing.length) {
+        return [...existing]
+      }
+
+      const initialIds = initial.map(() => Math.random().toString(36).slice(2))
+      arraysRef.current[name as string] = initialIds
+      arrayValuesRef.current[name as string] = initial.reduce<Record<string, any>>(
+        (acc, val, idx) => {
+          acc[initialIds[idx]] = val
+          return acc
+        },
+        {}
+      )
+      if (initialIds.length > 0) {
+        return initialIds
+      }
+      const first = Math.random().toString(36).slice(2)
+      arraysRef.current[name as string] = [first]
+      return [first]
+    })
+
+    useEffect(() => {
+      arraysRef.current[name as string] = ids
+    }, [ids])
+
+    function append(value?: ArrayValue<S[K]>) {
+      const id = Math.random().toString(36).slice(2)
+      setIds((list) => [...list, id])
+      if (value !== undefined) {
+        arrayValuesRef.current[name as string] = {
+          ...(arrayValuesRef.current[name as string] || {}),
+          [id]: value,
+        }
+      }
+    }
+
+    function remove(index: number) {
+      const id = ids[index]
+      setIds((list) => list.filter((_, i) => i !== index))
+      arrayValuesRef.current[name as string] = Object.keys(
+        arrayValuesRef.current[name as string] || {}
+      ).reduce<Record<string, any>>((acc, key) => {
+        if (key !== id) {
+          acc[key] = arrayValuesRef.current[name as string][key]
+        }
+        return acc
+      }, {})
+      setFields((f) => {
+        const next: FieldsMap = {}
+        for (const key in f) {
+          if (!key.startsWith(`${String(name)}.${id}.`)) {
+            next[key] = f[key]
+          }
+        }
+        return next
+      })
+    }
+
+    const fieldsArray = ids.map((id) => ({
+      id,
+      useFormField: (
+        child: string,
+        options?: Omit<Options<any>, 'formatErrorMessage' | 'name' | '_onUpdateValue'>
+      ) => useFormField(`${String(name)}.${id}.${child}`, options),
+    }))
+
+    return { fields: fieldsArray, append, remove }
+  }
+
   function touchFields() {
     for (const name in fields) {
       fields[name].update({ touched: true })
@@ -128,7 +314,7 @@ export default function useForm<S extends ZodRawShape>(
 
       touchFields()
 
-      const data = mapFieldsToData(fields)
+      const data = mapFieldsToData(fields, arraysRef.current)
       const parsed = schema.safeParse(data)
 
       if (parsed.success) {
@@ -147,6 +333,7 @@ export default function useForm<S extends ZodRawShape>(
 
   return {
     useFormField,
+    useFieldArray,
     handleSubmit,
     formProps,
     isDirty,


### PR DESCRIPTION
## Summary
- rewrite `setDeepValue` with immutable logic
- keep array default values and type checking for field arrays
- allow nested field names via `PathKeys` type
- restrict `useFieldArray` to array keys and support default values on append

## Testing
- `pnpm --filter ./packages/forms build`
- `pnpm --filter ./packages/forms test`


------
https://chatgpt.com/codex/tasks/task_e_687fe23b83088326bcd79fc43ec08d86