### PR TITLE
[Forms] Persisted Forms

### DIFF
--- a/packages/forms/package.json
+++ b/packages/forms/package.json
@@ -54,5 +54,8 @@
     "rimraf": "^3.0.2",
     "typescript": "^5.4.5",
     "zod": "4.0.0-beta.20250505T195954"
+  },
+  "dependencies": {
+    "@zod/core": "^0.11.6"
   }
 }

--- a/packages/forms/src/defaultFormatErrorMessage.ts
+++ b/packages/forms/src/defaultFormatErrorMessage.ts
@@ -1,5 +1,5 @@
-import { ZodIssue } from 'zod'
+import { $ZodIssue } from '@zod/core'
 
-export default function defaultFormatErrorMessage(error: ZodIssue) {
+export default function defaultFormatErrorMessage(error: $ZodIssue) {
   return error.message
 }

--- a/packages/forms/src/types.ts
+++ b/packages/forms/src/types.ts
@@ -1,4 +1,4 @@
-import { ZodIssue } from 'zod'
+import { $ZodIssue } from '@zod/core'
 
 export type Field<T> = {
   value: T
@@ -16,6 +16,8 @@ export type Options<T> = {
   touched?: boolean
   showValidationOn?: 'submit' | 'blur' | 'change'
   parseValue?: (e: any) => T
-  formatErrorMessage?: (error: ZodIssue, value: T, name?: string) => string
-  _onUpdateValue?: (value: T, dirty: boolean) => void
+  formatErrorMessage?: (error: $ZodIssue, value: T, name?: string) => string
+  _onInit?: (field: Field<T>) => void
+  _onUpdate?: (field: Partial<Field<T>>) => void
+  _storedField?: Field<T>
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,10 @@ importers:
         version: 5.4.5
 
   packages/forms:
+    dependencies:
+      '@zod/core':
+        specifier: ^0.11.6
+        version: 0.11.6
     devDependencies:
       '@types/react':
         specifier: ^18.3.3
@@ -1061,7 +1065,6 @@ packages:
 
   /@zod/core@0.11.6:
     resolution: {integrity: sha512-03Bv82fFSfjDAvMfdHHdGSS6SOJs0iCcJlWJv1kJHRtoTT02hZpyip/2Lk6oo4l4FtjuwTrsEQTwg/LD8I7dJA==}
-    dev: true
 
   /JSONStream@1.3.5:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}


### PR DESCRIPTION
This PR refactors the whole forms package to allow for persisted, more bulletproof form fields even on rerenders and nested components. This also lays the groundwork for the upcoming `useArrayField`